### PR TITLE
Use literal 0 instead of closure lookup

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const wait = ms => source => (start, sink) => {
   };
 
   source(start, (t, d) => {
-    if (t === start) {
+    if (t === 0) {
       talkback = d;
       sink(t, unsubInterceptor);
     } else {


### PR DESCRIPTION
Unless engine can optimize this this has to have some small cost, because of the nature of it - it has to lookup this value. Inlined should have better perf (theoretically and probably practically), but I'm not good with writing benchmarks, so cannot back this up with concrete numbers.