### PR TITLE
Reorder resource cleanup with emit to sink

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,8 +13,8 @@ const wait = ms => source => (start, sink) => {
       sink(t, unsubInterceptor);
     } else {
       const id = setTimeout(() => {
-        sink(t, d);
         ids.splice(ids.indexOf(id), 1);
+        sink(t, d);
       }, ms);
       ids.push(id);
       if (t === 1) talkback(t);


### PR DESCRIPTION
This probably has no difference in this scenario, but I find it better practice to clear resources before yielding control back to other code. With order used in the original code it's often easy to end up with a bug - mainly because of potential synchronous talkbacks.