### PR TITLE
Removed extra pull from wait

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,6 @@ const wait = ms => source => (start, sink) => {
         sink(t, d);
       }, ms);
       ids.push(id);
-      if (t === 1) talkback(t);
     }
   });
 };

--- a/test.js
+++ b/test.js
@@ -2,7 +2,7 @@ const tape = require('tape');
 const fromIter = require('callbag-from-iter');
 const wait = require('.');
 
-tape('It delays a pullable source', t => {
+tape('It delays each item from a pullable source', t => {
   t.plan(10);
 
   const sourceEmits = [
@@ -34,7 +34,7 @@ tape('It delays a pullable source', t => {
     t.equal(sinkReceives.length, sourceEmits.length, 'no data left');
     t.pass('nothing else happens');
     t.end();
-  }, 100);
+  }, 400);
 });
 
 tape('It delays a listenable source', t => {


### PR DESCRIPTION
Continuing our discussion from Twitter 😉 

I've thought about it for last days and I came to conclusion that implemented behaviour is incorrect for pullable sources (previously I had just doubts).

My reasoning is that pullable and listenable sources are different beasts and often cannot be treated the same way. Unfortunately I don't think there is previous work on which we could base our assumptions about the exact behaviours because callbags are unique - they support both types. 

There are multiple listenable stream libraries, Rx being the most popular it seems reasonable to take it as some kind of role model when it comes to testing/checking behaviours for listenable sources. I only know about `pull-stream` when it comes to pullable ones.

I don't think Rx `Observable.from([1,2,3,4]).delay(1000)` is equivalent to `pipe(fromIter([1,2,3,4]), wait(1000))` for the sole reason that former is listenable and latter is pullable, their behaviours just cant be compared, although at first it might seem like they should be because in terms of usage listenables and pullables dont differ that much, it's kinda a matter of internal implementation from user's perspective. IMHO callbags' equivalent to `Observable.from([1,2,3,4])` is `of(1,2,3,4)`.

Going back to pull stream world - there is this package - https://github.com/dweinstein/pull-delay which adheres to "delay each input" behaviour. I think it's a community operator, so its reasoning might be somewhat questioned, nevertheless it doesn't implement "draining" in `delay` itself - it leaves that responsibility to other operators in the chain.

To achieve "draining" behaviour with changes from this PR one could either use `of` instead of `fromIter` or just add `pump` in the chain (that would "drain" the pullable by converting it to listenable):
```js
pipe(
  fromIter([1,2,3,4]),
  pump,
  wait(1000),
)
```

Because this behaviour seems to be composable from other operators and the other one cannot be (`wait` that would delay each item) it's IMHO a better default behaviour.

Embedding pulls in `wait` leads also to somewhat questionable behaviour that in standard scenario each delivered item is causing **two** pulls - 1 immediate from `wait` and 1 delayed from the consuming sink (from the time when produced value reaches it).

If you don't agree, that's fine 😃Just let this PR hang in here